### PR TITLE
Clarify that headings are operative

### DIFF
--- a/agreement.commonform
+++ b/agreement.commonform
@@ -32,7 +32,7 @@ Terms of this Agreement Generally \\
 
     The Terms of this Agreement are Mutual \\ Each provision of this <Agreement> creates the same rights, remedies, and obligations for each <Party>.
 
-    Headings Summarize Provisions \\ Each heading of this <Agreement> summarizes the entire content of the provision that follows. 
+    Headings Summarize Provisions \\ Each heading of is an operative part of this <Agreement> that summarizes the entire content of the provision that follows. 
 
 Obligations \\
 


### PR DESCRIPTION
This small change makes absolutely clear that the Obvious NDA bucks the trend of contracts writing headings off as meaningless conveniences.

My aim in takign the opposite tack was to make first-time review easier. The finer division of provisions into sections, as well as the headings, are designed to make it easy to tick off the boxes of one's mental NDA checklist in the course of reading.

I considered providing expclitly that any part of a section not generalized by the relevant heading be struck from the agreement, but couldn't find a way to make that distinction sharp and predictable.